### PR TITLE
Reading in L1b data from read_mats_data

### DIFF
--- a/src/mats_utils/rawdata/read_data.py
+++ b/src/mats_utils/rawdata/read_data.py
@@ -4,7 +4,7 @@ from datetime import timezone
 from mats_l1_processing.read_parquet_functions import read_ccd_data_in_interval,add_ccd_item_attributes,remove_faulty_rows
 #%matplotlib widget
 
-def read_MATS_data(start_date,end_date,version='0.3',level='1a'):
+def read_MATS_data(start_date,end_date,version='0.4',level='1a'):
     session = boto3.session.Session(profile_name="mats")
     credentials = session.get_credentials()
 

--- a/src/mats_utils/rawdata/read_data.py
+++ b/src/mats_utils/rawdata/read_data.py
@@ -4,7 +4,7 @@ from datetime import timezone
 from mats_l1_processing.read_parquet_functions import read_ccd_data_in_interval,add_ccd_item_attributes,remove_faulty_rows
 #%matplotlib widget
 
-def read_MATS_data(start_date,end_date,version='0.3'):
+def read_MATS_data(start_date,end_date,version='0.3',level='1a'):
     session = boto3.session.Session(profile_name="mats")
     credentials = session.get_credentials()
 
@@ -18,8 +18,11 @@ def read_MATS_data(start_date,end_date,version='0.3'):
         start_date = start_date.replace(tzinfo=timezone.utc)
     if end_date.tzinfo == None:
         end_date = end_date.replace(tzinfo=timezone.utc)
-    
-    ccd_data = read_ccd_data_in_interval(start_date,end_date,"ops-payload-level1a-v" + version,s3)
-    add_ccd_item_attributes(ccd_data)
-    remove_faulty_rows(ccd_data)
+
+    ccd_data = read_ccd_data_in_interval(start_date, end_date, f"ops-payload-level{level}-v{version}", s3)
+
+    if level is 'l1a':
+        add_ccd_item_attributes(ccd_data)
+        remove_faulty_rows(ccd_data)
+
     return (ccd_data)

--- a/src/mats_utils/rawdata/read_data.py
+++ b/src/mats_utils/rawdata/read_data.py
@@ -21,7 +21,7 @@ def read_MATS_data(start_date,end_date,version='0.3',level='1a'):
 
     ccd_data = read_ccd_data_in_interval(start_date, end_date, f"ops-payload-level{level}-v{version}", s3)
 
-    if level is 'l1a':
+    if level is '1a':
         add_ccd_item_attributes(ccd_data)
         remove_faulty_rows(ccd_data)
 


### PR DESCRIPTION
Small change that allows l1b to be read.
Requires skipping add_ccd_item_attributes (which should prepare for calibration anyway?).
Seems like we miss variables such as 'channel', 'flipped' and a few temperatures.

