### PR TITLE
Common grid and parquet reading of MATS data

### DIFF
--- a/src/mats_utils/rawdata/read_data.py
+++ b/src/mats_utils/rawdata/read_data.py
@@ -6,6 +6,9 @@ from mats_l1_processing.read_parquet_functions import read_ccd_data_in_interval,
 import numpy as np
 import pandas as pd
 import pyarrow as pa  # type: ignore
+import datetime as DT
+import logging
+import pytz
 #%matplotlib widget
 
 
@@ -210,3 +213,147 @@ def read_MATS_payload_data(start_date,end_date,data_type='CCD',filter=None,versi
         raise Warning('Dataset is empty check version or time interval')
 
     return dataframe
+
+
+def store_as_parquet(df, fname):
+    """ Stores pandas dataframe to parquet file.
+        ImageCalibrated is flattened (do be restored after reading), as parquet can only handle 1-D ndarrays.
+
+        Args:
+           df - pandas dataframe to store;
+           fname - filename for the parquet file.
+
+        Returns:
+           Nothing.
+
+    """
+
+    df["ImageCalibrated"] = [arr.flatten() for arr in df["ImageCalibrated"]]
+    df.to_parquet(fname, compression='gzip', engine='pyarrow', allow_truncated_timestamps=True, coerce_timestamps='ms')
+
+
+def load_parquet(fname, start=None, stop=None, filt={}, fail_if_empty=True, fail_if_no_file=True):
+    """ Loads pandas dataframe from parquet file. Has similar args as read_MATS_data.
+
+        Args:
+            start - datetime, start of the time interval to retrieve;
+            stop - datetime, end of the time interval to retrieve;
+            filt - dict with entries of the form <pandas column name>: [<lower boundary>, <upper boundary>]
+                   to filter the data. Design to work similarly to read_MATS_data filters.
+            fail_if_empty - bool, if True, throws an error if filtered dataset ends up empty;
+            fail_if_no_file - bool, if True, throws and error if file for the appropriate time not found in
+                              the specified directory. False is useful for long data interfal retrieval in case
+                              of data gaps;
+
+        Returns:
+            res - pandas data frame with MATS data.
+
+    """
+
+    try:
+        df = pd.read_parquet(fname)
+    except Exception:
+        if fail_if_no_file:
+            raise FileNotFoundError(f"File {fname} not found or unreadable!")
+        else:
+            return None
+
+    valid = np.ones(len(df))
+    for col, lim in filt.items():
+        valid = np.logical_and(valid, df[col] >= lim[0])
+        valid = np.logical_and(valid, df[col] <= lim[1])
+
+    if start is not None:
+        valid = np.logical_and(valid, df["EXPDate"] >= start.replace(tzinfo=timezone.utc))
+    if stop is not None:
+        valid = np.logical_and(valid, df["EXPDate"] <= stop.replace(tzinfo=timezone.utc))
+
+    if not np.all(valid):
+        df = df[valid]
+    if len(df) == 0:
+        if fail_if_empty:
+            raise RuntimeError("There are no images in this data set! Adjust start and stop times or filters!")
+        else:
+            return df
+
+    df["ImageCalibrated"] = [arr.reshape((df["NROW"].iloc[i], df["NCOL"].iloc[i] + 1))
+                             for i, arr in enumerate(df["ImageCalibrated"])]
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def load_multi_parquet(dirname, start, stop, filt={}, fail_if_empty=True):
+    """ Loads pandas dataframe from parquet files from specified directory. If the specified time interval spans
+        multiple files, the loaded data sets are merged. Has similar args as read_MATS_data.
+
+        Args:
+            start - datetime, start of the time interval to retrieve;
+            stop - datetime, end of the time interval to retrieve;
+            filt - dict with entries of the form <pandas column name>: [<lower boundary>, <upper boundary>]
+                   to filter the data. Design to work similarly to read_MATS_data filters;
+            fail_if_empty - bool, if True, throws an error if filtered dataset ends up empty.
+
+        Returns:
+            res - pandas data frame with MATS data.
+
+    """
+
+    hours = all_hours(start, stop)
+    fnames = [f"{dirname}/{hours_filename(h)}" for h in hours]
+
+    if len(hours) == 1:
+        return load_parquet(fnames[0], start=start, stop=stop, filt=filt,
+                            fail_if_empty=fail_if_empty)
+    else:
+        dfs = [load_parquet(fnames[0], start=start, stop=hours[1], filt=filt,
+                            fail_if_empty=False, fail_if_no_file=False)]
+        for i in range(1, len(hours) - 1):
+            dfs.append(load_parquet(fnames[i], start=hours[1], stop=hours[i + 1], filt=filt,
+                                    fail_if_empty=False, fail_if_no_file=False))
+        dfs.append(load_parquet(fnames[-1], start=hours[-1], stop=stop, filt=filt,
+                                fail_if_empty=False, fail_if_no_file=False))
+
+    dfs = [x for x in dfs if x is not None]
+    if len(dfs) != len(hours):
+        if len(dfs) == 0:
+            raise FileNotFoundError("None of the files for the specified time interval found! " +
+                                    "Check time interval and directory!")
+        else:
+            logging.warn("Some files in the time interval were missing, likely because of missing data.")
+
+    res = pd.concat(dfs, axis=0)
+    res.reset_index(drop=True, inplace=True)
+    if fail_if_empty and len(res) == 0:
+        raise ValueError("No data matching the criteria found in the time interval!")
+    else:
+        return res
+
+
+def all_hours(start, stop):
+    """ Helper function that returns a list of datetime objects for every exact hour starting with the hour
+        before start and ending with the hour before stop.
+
+        Args:
+            start - datetime, the start of time interval;
+            stop - datetime, the end of time interval;
+
+        Returns:
+            list of datetime.
+    """
+    if start > stop:
+        raise ValueError("Start of the given time interval is later than the end!")
+    first = start.replace(second=0, microsecond=0, minute=0)
+    numhours = int(np.ceil((stop - first) / DT.timedelta(hours=1)))
+    return [first + i * DT.timedelta(hours=1) for i in range(numhours)]
+
+
+def hours_filename(time):
+    """ Returns the standard file name for parquet file starting at specified time.
+
+        Args:
+            time - datetime;
+
+        Returns:
+            str with the standard file name.
+    """
+    return f"{time.year}-{time.month:02d}-{time.day:02d}_{time.hour:02d}.parquet.gzip"


### PR DESCRIPTION
* Common grid: Mapping all channels on the same grid, angle based in both x and y
* Reading MATS data from parquet files: Option in order to store the data outside of AWS. The function returns a dataframe in a similar way as read_MATS_data does with AWSdata 